### PR TITLE
chore(gitignore): update ignore rules for Playwright, env configs, an…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,18 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/.auth/
+/logs/
+/downloads/
+/ortoni-report/
+dist/
+results.trx
+results.xml
+
+# Environment configuration
+.env*
+!*.template
+
+
+# Intentionally tracked
+# .vscode/ - keeping this tracked as it contains project-specific prettier setup


### PR DESCRIPTION
…d build artifacts

- Ignored Playwright outputs (test-results, reports, cache, logs, downloads)
- Added env configuration ignores (`.env*` with template exception)
- Ignored build artifacts (dist, trx/xml results, ortoni-report)
- Kept `.vscode/` tracked for Prettier setup