### PR TITLE
feat(timeout): add centralized TimeoutManager with environment-aware …

### DIFF
--- a/src/configuration/timeouts/timeout.config.ts
+++ b/src/configuration/timeouts/timeout.config.ts
@@ -1,0 +1,31 @@
+import TimeoutManager from "./timeoutManager";
+
+export const TIMEOUTS = {
+  test: TimeoutManager.timeout(40_000),
+  expect: TimeoutManager.timeout(35_000),
+
+  api: {
+    standard: TimeoutManager.timeout(10_000),
+    upload: TimeoutManager.timeout(60_000),
+    download: TimeoutManager.timeout(90_000),
+    healthCheck: TimeoutManager.timeout(3_000),
+    connection: TimeoutManager.timeout(8_000),
+  },
+
+  db: {
+    query: TimeoutManager.timeout(15_000),
+    transaction: TimeoutManager.timeout(30_000),
+    migration: TimeoutManager.timeout(120_000),
+    connection: TimeoutManager.timeout(10_000),
+    request: TimeoutManager.timeout(10_000),
+    poolAcquisition: TimeoutManager.timeout(10_000),
+    idle: TimeoutManager.timeout(10_000),
+  },
+} as const;
+
+export const {
+  test: TEST_TIMEOUT,
+  expect: EXPECT_TIMEOUT,
+  api: API_TIMEOUT,
+  db: DB_TIMEOUT,
+} = TIMEOUTS;

--- a/src/configuration/timeouts/timeoutManager.ts
+++ b/src/configuration/timeouts/timeoutManager.ts
@@ -1,0 +1,9 @@
+import EnvironmentDetector from "../environment/detector/environmentDetector";
+
+export default class TimeoutManager {
+  private static CI_MULTIPLIER = 2;
+
+  public static timeout(base: number): number {
+    return EnvironmentDetector.isCI() ? base * TimeoutManager.CI_MULTIPLIER : base;
+  }
+}


### PR DESCRIPTION
…scaling

- Implemented `TimeoutManager` to apply CI multiplier for timeouts
- Defined standardized timeout constants for tests, API calls, and DB operations
- Exported `TEST_TIMEOUT`, `EXPECT_TIMEOUT`, `API_TIMEOUT`, and `DB_TIMEOUT` for reuse